### PR TITLE
Update RNToastNative.m

### DIFF
--- a/ios/RNToastNative.m
+++ b/ios/RNToastNative.m
@@ -19,6 +19,10 @@ NSInteger const RNToastNativeGravityTop = 3;
     CGFloat _keyOffset;
 }
 
++ (BOOL) requiresMainQueueSetup {
+Return YES;
+}
+
 - (instancetype)init {
     if (self = [super init]) {
         _keyOffset = 0;


### PR DESCRIPTION
Hi, I added that code block to RNToastNative.m and the warning about _requiresMainQueueSetup_ was  disappeared.
```
+ (BOOL) requiresMainQueueSetup {
    return YES;
}
```