### PR TITLE
Fix: RNToastNative has a warning [requiresMainQueueSetup]

### DIFF
--- a/ios/RNToastNative.m
+++ b/ios/RNToastNative.m
@@ -19,6 +19,11 @@ NSInteger const RNToastNativeGravityTop = 3;
     CGFloat _keyOffset;
 }
 
+// Fix: RNToastNative has a warning [requiresMainQueueSetup]
++ (BOOL) requiresMainQueueSetup {
+    return YES;
+}
+
 - (instancetype)init {
     if (self = [super init]) {
         _keyOffset = 0;


### PR DESCRIPTION
I added the following code in the RNToastNative

+ (BOOL) requiresMainQueueSetup {
return YES;
}
Warnings will disappear.

react-native 0.56.0